### PR TITLE
Add 240fps issue

### DIFF
--- a/docs/control/overlays/README.md
+++ b/docs/control/overlays/README.md
@@ -77,7 +77,7 @@ Cool Tips:
 - A range (not all) of GoPro metadata can be displayed in their stored units, so speed is in meters/sec, not MPH. For more technical information on [GoPro's GPMF Metadata](https://gopro.github.io/gpmf-parser/) and other metadata you can display.
 
 Known Issues:
-- not working correctly in 4K50 and 4K60 video modes and Timelapse 4K.
+- not working correctly in 4K50, 4K60 and 1080p240 video modes and Timelapse 4K.
 - does not update the time and metadata when used with motion detection triggered captures.
 - Metadata can take a second before it updates after capture start.
 		


### PR DESCRIPTION
If trying to record with an overlay in 1080p240fps the screen on the gopro drops a lot of frames and goes very choppy.

The video doesn't seem to record at the proper framerate either and the overlay is glitched - see https://www.youtube.com/watch?v=3zyOqmgzsNI for an example where the overlay is glitching at the bottom.

This PR just adds recording in 1080p240 to the list of known issues