### PR TITLE
Fix bottom-center overlay not working

### DIFF
--- a/docs/control/overlays/README.md
+++ b/docs/control/overlays/README.md
@@ -58,7 +58,7 @@ Examples:
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
   <input type="radio" id="sp5" name="placement" value="MR"><label for="sp5">Mid Right   </label><br>
   &nbsp;&nbsp;&nbsp;&nbsp;<input type="radio" id="sp6" name="placement" value="BL"><label for="sp6">Lower Left  </label>&nbsp;
-  <input type="radio" id="b7" name="placement" value="BC"><label for="sp7">Lower Center</label>&nbsp;
+  <input type="radio" id="sp7" name="placement" value="BC"><label for="sp7">Lower Center</label>&nbsp;
   <input type="radio" id="sp8" name="placement" value="BR" checked><label for="sp8">Lower Right </label>&nbsp;<br>
   
 <center>


### PR DESCRIPTION
Currently, selecting a bottom-center overlay on the Overlays screen generates an invalid QR code that scans, but doesn't take effect.

The input id being named `b7` seems to stop it getting picked up when the QR code is generated, the output is:
```
oMBRNO=10oMBURN="(0,318)[HH:MM:SSaa\nmm-dd-yyyy]"
```

When it should be:
```
oMBRNO=10oMBURN="(0,318)[BCHH:MM:SSaa\nmm-dd-yyyy]"

```

This PR just renames the ID so it's in line with the others, which fixes the problem.