### PR TITLE
Clarify Action Commands Header

### DIFF
--- a/docs/control/actions/README.md
+++ b/docs/control/actions/README.md
@@ -1,4 +1,4 @@
-# Full List the Action Commands
+# Full List of Action Commands
 
 <script src="../../jquery.min.js"></script>
 <script src="../../qrcodeborder.js"></script>


### PR DESCRIPTION
It seems like this should read "Full List of Action Commands" rather than "Full List the Action Commands."

Alternatively, maybe it was supposed to be "Full List of the Action Commands."